### PR TITLE
Comparison to allow urls without extension always failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,7 +385,7 @@ Versions.prototype.allows = function allows(what, req) {
 
       // Don't accept queries without file extensions and ignore blacklisted
       // extensions
-      return (this.get('force extensions') && req.extension !== '')
+      return ((this.get('force extensions') && req.extension !== '') || !this.get('force extensions'))
         && !~this.get('blacklisted extensions').indexOf(req.extension);
 
     // Does this request allow 304 requests?

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -276,14 +276,20 @@ describe('version.layer() integration', function () {
           done();
         });
       });
+    });
 
-      it('doesnt allow files without extensions', function () {
+    it('doesnt allow files without extensions', function (done) {
+      versions.app.request()
+      .get('/id:home/')
+      .end(function (get) {
+        expect(get.statusCode).to.equal(404);
+        versions.set('force extensions', false);
+        
         versions.app.request()
-        .get('/id:home/')
-        .end(function (get) {
-          expect(get.statusCode).to.equal(404);
-          versions.set('force extensions', false);
-
+        .head('/id:home/')
+        .end(function (head) {
+          expect(head.statusCode).to.equal(200);
+          
           versions.app.request()
           .head('/id:home/img/sprite.png')
           .end(function (head) {


### PR DESCRIPTION
When the option 'force extensions' was set to false, the comparison in #allows always returned false, so it always returned a 404. The tests didn't reflect this, because it was not properly nested.
