### PR TITLE
Expire individual keys

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -43,6 +43,22 @@ var routes = {
 
     res.JSON({ flush: 'OK' });
   },
+  
+  /**
+   * Expire a specific item in the cache, specified by ?key=<keyname>
+   */
+  '/expire': function expire(req, res, next) {
+    var query = req.uri.query;
+    var _cache = this.cache;
+    this.cache.forEach(function(key) {
+      if(query && ~key.indexOf(query.key)) {
+        _cache.remove(key);
+      }
+    });
+    
+    this.metrics.incr('expire', { req: req, res: res });
+    res.JSON({ expire: 'OK' });
+  },
 
   /**
    * Inspects an item in the cache, use ?key=<keyname> to inspect the cache

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -462,6 +462,30 @@ describe('version.layer() integration', function () {
         });
       });
     });
+    
+    describe('/expire', function() {
+      before(function(done) {
+        versions.app.request()
+        .get('/id:home/img/sprite.png')
+        .end(function (res) { done(); });
+      })
+      
+      it('removes a specific entry in the cache', function(done) {
+        expect(versions.cache.length).to.be.above(0);
+        var cacheLength = versions.cache.length;
+        
+        versions.app.request()
+        .get('/expire?auth=foobar&key=' + escape('#/id:home/img/sprite.png'))
+        .end(function(res) {
+          expect(res.body).to.contain('OK');
+          expect(res.statusCode).to.equal(200);
+          expect(versions.cache.length).to.equal(cacheLength - 1);
+          expect(versions.cache.has('#/img/sprite.png')).to.be.false;
+          
+          done();
+        });
+      });
+    });
   });
 
   describe('.layer(versioning)', function () {


### PR DESCRIPTION
This PR adds a route to expire a specific key, for when '/flush' isn't subtle enough.

Particularly useful when used as a frontend for a web application where you immediately need to reflect changes in the frontend without invalidating your entire cache. 
